### PR TITLE
get rid of construct.Embedded to support python version >3.11

### DIFF
--- a/axeman/certlib.py
+++ b/axeman/certlib.py
@@ -12,7 +12,7 @@ CTL_INFO = "https://{}/ct/v1/get-sth"
 
 DOWNLOAD = "https://{}/ct/v1/get-entries?start={}&end={}"
 
-from construct import Struct, Byte, Int16ub, Int64ub, Enum, Bytes, Int24ub, this, GreedyBytes, GreedyRange, Terminated, Embedded
+from construct import Struct, Byte, Int16ub, Int64ub, Enum, Bytes, Int24ub, this, GreedyBytes, GreedyRange, Terminated
 
 MerkleTreeHeader = Struct(
     "Version"         / Byte,
@@ -34,7 +34,7 @@ CertificateChain = Struct(
 
 PreCertEntry = Struct(
     "LeafCert" / Certificate,
-    Embedded(CertificateChain),
+    "CertificateChain" / CertificateChain,
     Terminated
 )
 

--- a/axeman/core.py
+++ b/axeman/core.py
@@ -190,7 +190,7 @@ def process_worker(result_info):
                 extra_data = certlib.PreCertEntry.parse(base64.b64decode(entry['extra_data']))
                 chain = [crypto.load_certificate(crypto.FILETYPE_ASN1, extra_data.LeafCert.CertData)]
 
-                for cert in extra_data.Chain:
+                for cert in extra_data.CertificateChain.Chain:
                     chain.append(
                         crypto.load_certificate(crypto.FILETYPE_ASN1, cert.CertData)
                     )
@@ -248,7 +248,7 @@ async def get_certs_and_print():
             print(log['description'])
             print("    \- URL:            {}".format(log['url']))
             print("    \- Owner:          {}".format(log_info['operated_by']))
-            print("    \- Cert Count:     {}".format(locale.format("%d", log_info['tree_size']-1, grouping=True)))
+            print("    \- Cert Count:     {}".format(locale.format_string("%d", log_info['tree_size']-1, grouping=True)))
             print("    \- Max Block Size: {}\n".format(log_info['block_size']))
 
 def main():

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ uvloop
 aiohttp
 aioprocessing
 PyOpenSSL
-construct==2.9.52
+construct


### PR DESCRIPTION
The construct.Embedded feature has been removed in newer versions of the Construct library, as substructure fields are now automatically flattened in most cases. If you’re using a modern version of Construct, you can safely remove Embedded from your code, and the fields from the substructure should still be accessible as part of the parent structure.